### PR TITLE
proper handling of unicode

### DIFF
--- a/defexpand/infoclass.py
+++ b/defexpand/infoclass.py
@@ -2,9 +2,11 @@ from HTMLParser import HTMLParser
 import json
 import config
 import re
-from unidecode import unidecode
 
+# load infoclasses and convert from unicode to str
 infoclass_pairs = json.load(open(config.DATA_DIRECTORY + 'infoclasses.json', 'r'))
+infoclass_pairs = [[s.encode('utf-8') if s else None for s in l]
+                   for l in infoclass_pairs]
 
 class InfoOntology():
     def __init__(self):
@@ -93,8 +95,6 @@ class InfoOntology():
 
     def classes_above_infobox(self, infobox):
         wiki_class = self.infoclass_dict.get(infobox, '')
-        if isinstance(wiki_class, unicode):
-            wiki_class = unidecode(wiki_class)
         return self.classes_above(wiki_class)
 
     def print_tree(self, wiki_class, indent=''):

--- a/defexpand/infoclass.py
+++ b/defexpand/infoclass.py
@@ -93,7 +93,8 @@ class InfoOntology():
 
     def classes_above_infobox(self, infobox):
         wiki_class = self.infoclass_dict.get(infobox, '')
-        wiki_class = unidecode(wiki_class)
+        if isinstance(wiki_class, unicode):
+            wiki_class = unidecode(wiki_class)
         return self.classes_above(wiki_class)
 
     def print_tree(self, wiki_class, indent=''):


### PR DESCRIPTION
Originally, `classes_above_infobox()` would return a unicode object for the infobox's wiki_class, and then the rest of the "classes_above" as regular strings. Ex:

``` Python
>>> from defexpand import infoclass
>>> ontology = infoclass.get_info_ontology()
>>> ontology.classes_above_infobox('officeholder')
[u'OfficeHolder', 'Person', 'Agent', 'owl:Thing']
```

I though this was annoying and could interfere with subsequent analysis, so I made the change to `unidecode` wiki_class in commit 6bbcdedf3c54cf330faa592412daf63bfadd702e (which, I apologize, I did not make a PR for).

Now, I'm being careful and polite, so I made a PR. (Did not make an issue because this is sort of a patch for a would-be-PR for a would-be-issue.) Sometimes, wiki_class is not a unicode object, such as when a non-existant infobox is used (e.g. 'officeholder' returns unicode, but 'junk' returns string). So, I get this warning:

```
/scratch/msilver/.virtualenvs/wikimap/local/lib/python2.7/site-packages/defexpand-0.1.1-py2.7.egg/defexpand/infoclass.py:96: RuntimeWarning: Argument <type 'str'> is not an unicode object. Passing an encoded string will likely have unexpected results.
  wiki_class = unidecode(wiki_class)
```

Thus, I propose to check whether `wiki_class` is unicode before decoding it, getting rid of this warning and any "unexpected results" that accompany it.
